### PR TITLE
Add fixed navbar with mobile hamburger menu

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -119,7 +119,7 @@
 
 /* Utility: balanced headings and section spacing */
 .section {
-  @apply py-12 md:py-16;
+  @apply py-12 md:py-16 scroll-mt-24 md:scroll-mt-28;
 }
 .section-muted {
   @apply bg-muted/60;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ import { Contact } from "@/components/sections/contact"
 
 export default function Page() {
   return (
-    <main>
+    <main className="pt-24 md:pt-28">
       <SiteHeader />
       <Hero />
       <AvailableArtworks />

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -6,9 +6,7 @@ export function Hero() {
       {/* full-bleed hero image */}
       <div className="relative h-[360px] md:h-[520px] lg:h-[560px]">
         <img
-          src={`/.jpg?height=1120&width=1920&query=${encodeURIComponent(
-            "black and white portrait close up face on right side"
-          )}`}
+          src="/placeholder.svg"
           alt="Black and white portrait facing right"
           className="absolute inset-0 h-full w-full object-cover"
         />

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -2,7 +2,7 @@
 
 export function Hero() {
   return (
-    <section id="home" className="relative">
+    <section id="home" className="relative scroll-mt-24 md:scroll-mt-28">
       {/* full-bleed hero image */}
       <div className="relative h-[360px] md:h-[520px] lg:h-[560px]">
         <img

--- a/components/sections/available-artworks.tsx
+++ b/components/sections/available-artworks.tsx
@@ -75,7 +75,7 @@ export function AvailableArtworks() {
             {artworks.map((a) => (
               <article key={`${a.title}-${a.size}`} className="group bg-muted/80 p-3 rounded-md">
                 <img
-                  src={a.imageUrl ?? `/.jpg?height=360&width=540&query=${encodeURIComponent(a.placeholderQuery)}`}
+                  src={a.imageUrl ?? '/placeholder.svg'}
                   alt={a.alt}
                   className="w-full h-48 object-cover rounded-sm bg-muted"
                 />

--- a/components/sections/painting-portfolio.tsx
+++ b/components/sections/painting-portfolio.tsx
@@ -57,8 +57,8 @@ export function PaintingPortfolio() {
         <h2 className="font-serif text-3xl md:text-4xl tracking-tight text-center">Painting Portfolio</h2>
         <div className="mt-8 flex justify-center">
           <div className="grid w-full max-w-4xl grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
-            {items.map((it) => (
-              <article key={it.title} className="group bg-muted/80 p-3 rounded-md">
+            {items.map((it, idx) => (
+              <article key={it.imageUrl ?? `${it.title}-${idx}`} className="group bg-muted/80 p-3 rounded-md">
                 <img
                   src={it.imageUrl}
                   alt={it.alt}

--- a/components/sections/painting-portfolio.tsx
+++ b/components/sections/painting-portfolio.tsx
@@ -58,7 +58,7 @@ export function PaintingPortfolio() {
         <div className="mt-8 flex justify-center">
           <div className="grid w-full max-w-4xl grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
             {items.map((it, idx) => (
-              <article key={it.imageUrl ?? `${it.title}-${idx}`} className="group bg-muted/80 p-3 rounded-md">
+              <article key={`${it.imageUrl ?? it.title}-${idx}`} className="group bg-muted/80 p-3 rounded-md">
                 <img
                   src={it.imageUrl}
                   alt={it.alt}

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -50,7 +50,11 @@ export function SiteHeader() {
       <nav
         id="mobile-navigation"
         aria-label="Primary"
-        className={`${isMenuOpen ? "block" : "hidden"} md:hidden border-t border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80`}
+        className={
+          isMenuOpen
+            ? "block border-t border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 md:hidden"
+            : "hidden border-t border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 md:hidden"
+        }
       >
         <ul className="flex flex-col gap-3 px-4 py-4">
           {links.map((link) => (

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -1,6 +1,8 @@
 "use client"
 
+import { useState } from "react"
 import Link from "next/link"
+import { Menu, X } from "lucide-react"
 
 const links = [
   { href: "#home", label: "Home" },
@@ -11,25 +13,59 @@ const links = [
 ]
 
 export function SiteHeader() {
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+
+  const toggleMenu = () => setIsMenuOpen((previous) => !previous)
+  const handleNavigate = () => setIsMenuOpen(false)
+
   return (
-    <header className="w-full border-b border-border bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <div className="mx-auto max-w-6xl px-4 py-4 flex items-center justify-between">
-        <Link href="#home" className="text-sm md:text-base font-medium tracking-tight">
+    <header className="fixed inset-x-0 top-0 z-50 w-full border-b border-border bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4">
+        <Link href="#home" className="text-sm font-medium tracking-tight md:text-base" onClick={handleNavigate}>
           jaykarun.com
           <span className="sr-only">Go to home</span>
         </Link>
         <nav aria-label="Primary" className="hidden md:block">
           <ul className="flex items-center gap-6">
-            {links.map((l) => (
-              <li key={l.href}>
-                <a href={l.href} className="text-sm hover:underline underline-offset-4">
-                  {l.label}
+            {links.map((link) => (
+              <li key={link.href}>
+                <a href={link.href} className="text-sm hover:underline underline-offset-4">
+                  {link.label}
                 </a>
               </li>
             ))}
           </ul>
         </nav>
+        <button
+          type="button"
+          className="inline-flex items-center justify-center rounded-md border border-border px-3 py-2 text-sm font-medium md:hidden"
+          aria-expanded={isMenuOpen}
+          aria-controls="mobile-navigation"
+          onClick={toggleMenu}
+        >
+          <span className="sr-only">Toggle navigation</span>
+          {isMenuOpen ? <X className="h-5 w-5" aria-hidden="true" /> : <Menu className="h-5 w-5" aria-hidden="true" />}
+        </button>
       </div>
+      <nav
+        id="mobile-navigation"
+        aria-label="Primary"
+        className={`${isMenuOpen ? "block" : "hidden"} md:hidden border-t border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80`}
+      >
+        <ul className="flex flex-col gap-3 px-4 py-4">
+          {links.map((link) => (
+            <li key={link.href}>
+              <a
+                href={link.href}
+                className="block text-sm font-medium"
+                onClick={handleNavigate}
+              >
+                {link.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
     </header>
   )
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,13 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  // allow preview/proxy origins (e.g. Builder preview on fly.dev) to request dev assets
+  allowedDevOrigins: [
+    'http://localhost:3000',
+    'http://127.0.0.1:3000',
+    'https://*.fly.dev',
+    'https://*.vercel.app'
+  ],
 }
 
 export default nextConfig


### PR DESCRIPTION
## Purpose

Based on user requirements to improve navigation accessibility and mobile experience:
- Keep navbar fixed during scrolling so users can access navigation from any section
- Add hamburger menu for mobile devices only
- Maintain existing desktop navbar design

## Code changes

- **Fixed positioning**: Made header fixed with `fixed inset-x-0 top-0 z-50` and added backdrop blur
- **Mobile hamburger menu**: Added toggle state management with Menu/X icons from lucide-react
- **Responsive navigation**: Hidden desktop nav on mobile, collapsible mobile nav with proper ARIA attributes
- **Scroll offset adjustments**: Added `scroll-mt-24 md:scroll-mt-28` to sections and `pt-24 md:pt-28` to main content to account for fixed header
- **Image placeholder fixes**: Replaced dynamic image URLs with `/placeholder.svg` for consistency
- **Key prop fixes**: Added proper unique keys for mapped components
- **Dev configuration**: Added allowed dev origins for preview environments

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/155d4e5735e041b7a928a8511b3a9032/echo-haven)

👀 [Preview Link](https://155d4e5735e041b7a928a8511b3a9032-echo-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>155d4e5735e041b7a928a8511b3a9032</projectId>-->
<!--<branchName>echo-haven</branchName>-->